### PR TITLE
mark assembler as not needing exec stack

### DIFF
--- a/src/misc_asm.S
+++ b/src/misc_asm.S
@@ -58,3 +58,5 @@ memcmp_consttime:
 .cfi_endproc
 .size	memcmp_consttime, .-memcmp_consttime
 .size   memcmp_consttime,.-memcmp_consttime
+
+.section        .note.GNU-stack,"",@progbits


### PR DESCRIPTION
so library does not need executable stack