### PR TITLE
Exploit KBLOB2PROTK3 ioctl support for clear EC and AES keys  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 arch:     s390x
 os:       linux
-dist:     bionic
+dist:     focal
 language: cpp
 sudo:     required
 env:      |

--- a/src/aes_key_local.h
+++ b/src/aes_key_local.h
@@ -62,5 +62,7 @@ struct zpc_aes_key {
 
 int aes_key_sec2prot(struct zpc_aes_key *, enum aes_key_sec sec);
 int aes_key_check(const struct zpc_aes_key *);
+int aes_key_clr2prot(struct zpc_aes_key *, const unsigned char *key,
+			unsigned int keylen);
 
 #endif

--- a/src/ecc_key_local.h
+++ b/src/ecc_key_local.h
@@ -63,4 +63,6 @@ int ec_key_clr2sec(struct zpc_ec_key *ec_key, unsigned int flags,
 			const unsigned char *privkey, unsigned int privlen);
 int ec_key_sec2prot(struct zpc_ec_key *, enum ec_key_sec sec);
 int ec_key_check(const struct zpc_ec_key *);
+int ec_key_clr2prot(struct zpc_ec_key *ec_key, const unsigned char *privkey,
+			unsigned int privlen);
 #endif

--- a/src/zkey/pkey.c
+++ b/src/zkey/pkey.c
@@ -418,3 +418,11 @@ const size_t curve2rawspkilen[] = {
 	sizeof(ed25519_maced_spki_t) - EP11_SPKI_MACLEN,
 	sizeof(ed448_maced_spki_t) - EP11_SPKI_MACLEN,
 };
+
+const u32 curve2pkey_keytype[] = {
+	PKEY_KEYTYPE_ECC_P256,
+	PKEY_KEYTYPE_ECC_P384,
+	PKEY_KEYTYPE_ECC_P521,
+	PKEY_KEYTYPE_ECC_ED25519,
+	PKEY_KEYTYPE_ECC_ED448,
+};

--- a/src/zkey/pkey.h
+++ b/src/zkey/pkey.h
@@ -259,6 +259,22 @@ struct pkey_clrkey {
 #define PKEY_KEYTYPE_AES_192	2
 #define PKEY_KEYTYPE_AES_256	3
 #define PKEY_KEYTYPE_ECC		4
+#define PKEY_KEYTYPE_ECC_P256         5
+#define PKEY_KEYTYPE_ECC_P384         6
+#define PKEY_KEYTYPE_ECC_P521         7
+#define PKEY_KEYTYPE_ECC_ED25519      8
+#define PKEY_KEYTYPE_ECC_ED448        9
+
+/* inside view of a clear key token (type 0x00 version 0x02) */
+struct clearkeytoken {
+	u8 type; /* 0x00 for PAES specific key tokens */
+	u8 res0[3];
+	u8 version; /* 0x02 for clear key token */
+	u8 res1[3];
+	u32 keytype; /* key type, one of the PKEY_KEYTYPE_* values */
+	u32 len; /* bytes actually stored in clearkey[] */
+	u8 clearkey[]; /* clear key value */
+} __packed;
 
 struct pkey_genseck {
 	u16 cardnr;			/* in: card to use or FFFF for any */


### PR DESCRIPTION
Newer kernels (6.5 and later) support converting clear EC private keys to protected keys via ioctl KBLOB2PROTK3. For AES, this support was already available longer, but not yet exploited in libzpc. 