### PR TITLE
New libzpc version 1.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 Changelog {#changes}
 ===
 
+**Version 1.2.0**
+
+- Support for get/set intermediate iv for CBC and XTS
+- Support for internal iv for GCM
+- Fix AES EP11 version 6 key support for generate and import_clear
+- Exploit KBLOB2PROTK3 ioctl for clear AES and EC keys
+
 **Version 1.1.1**
 
 - Exploit PKEY_KBLOB2PROTK2 for AES EP11 version 6 keys

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@
 set(ZPC_NAME          "libzpc"                            )
 set(ZPC_DESCRIPTION   "IBM Z Protected-key Crypto library")
 set(ZPC_VERSION_MAJOR 1                                   )
-set(ZPC_VERSION_MINOR 1                                   )
-set(ZPC_VERSION_PATCH 1                                   )
+set(ZPC_VERSION_MINOR 2                                   )
+set(ZPC_VERSION_PATCH 0                                   )
 ###########################################################
 
 cmake_minimum_required(

--- a/libzpc.spec
+++ b/libzpc.spec
@@ -1,5 +1,5 @@
 Name:		libzpc
-Version:	1.1.1
+Version:	1.2.0
 Release:	1%{?dist}
 Summary:	Open Source library for the IBM Z Protected-key crypto feature
 
@@ -88,6 +88,10 @@ The %{name}-static package contains the static library of %{name}.
 
 
 %changelog
+* Thu Dec 07 2023 Joerg Schmidbauer <jschmidb@de.ibm.com> - 1.2.0
+- Support for get/set intermediate iv for CBC and XTS.
+- Support for internal iv for GCM.
+
 * Fri Sep 15 2023 Joerg Schmidbauer <jschmidb@de.ibm.com> - 1.1.1
 - Exploit PKEY_KBLOB2PROTK2 for AES EP11 version 6 keys.
 


### PR DESCRIPTION
[FEATURE] Support for get/set intermediate iv for CBC and XTS 
[FEATURE] Support for internal iv for GCM
[FEATURE] Exploit KBLOB2PROTK3 ioctl for clear AES and EC keys 
[PATCH] Fix AES EP11 version 6 key support for generate and import_clear