### PR TITLE
New libzpc version 1.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Changelog {#changes}
 ===
 
+**Version 1.3.0**
+
+- Support for Ultravisor retrievable secrets
+- Handle CCA cipher key token with Encrypted V0 payload
+- bug fixes
+
 **Version 1.2.0**
 
 - Support for get/set intermediate iv for CBC and XTS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(ZPC_NAME          "libzpc"                            )
 set(ZPC_DESCRIPTION   "IBM Z Protected-key Crypto library")
 set(ZPC_VERSION_MAJOR 1                                   )
-set(ZPC_VERSION_MINOR 2                                   )
+set(ZPC_VERSION_MINOR 3                                   )
 set(ZPC_VERSION_PATCH 0                                   )
 ###########################################################
 

--- a/libzpc.spec
+++ b/libzpc.spec
@@ -1,5 +1,5 @@
 Name:		libzpc
-Version:	1.2.0
+Version:	1.3.0
 Release:	1%{?dist}
 Summary:	Open Source library for the IBM Z Protected-key crypto feature
 
@@ -88,6 +88,9 @@ The %{name}-static package contains the static library of %{name}.
 
 
 %changelog
+* Fri Feb 07 2025 Joerg Schmidbauer <jschmidb@de.ibm.com> - 1.3.0
+- Support for UV retrievable secrets.
+
 * Thu Dec 07 2023 Joerg Schmidbauer <jschmidb@de.ibm.com> - 1.2.0
 - Support for get/set intermediate iv for CBC and XTS.
 - Support for internal iv for GCM.


### PR DESCRIPTION
[FEATURE] Support for Ultravisor retrievable secrets 
[PATCH] Handle CCA cipher key token with Encrypted V0 payload 
[PATCH] bug fixes