### PR TITLE
TEST: fix probable segfault in tests

### DIFF
--- a/test/testlib.cc
+++ b/test/testlib.cc
@@ -300,8 +300,10 @@ testlib_env_aes_key_apqns(const char *apqns[257])
 	int i;
 
 	env = getenv(ENV_AES_KEY_APQNS);
-	if (env == NULL)
+	if (env == NULL) {
+		apqns[0] = NULL;
 		return -1;
+	}
 
 	i = 0;
 	tok = strtok(env, " \t\n,");
@@ -322,8 +324,10 @@ testlib_env_ec_key_apqns(const char *apqns[257])
 	int i;
 
 	env = getenv(ENV_EC_KEY_APQNS);
-	if (env == NULL)
+	if (env == NULL) {
+		apqns[0] = NULL;
 		return -1;
+	}
 
 	i = 0;
 	tok = strtok(env, " \t\n,");


### PR DESCRIPTION
When running the tests with env variables ZPC_TEST_AES_KEY_MKVP or ZPC_TEST_EC_KEY_MKVP a segfault may occur. Tests do not evaluate the rc of routines testlib_env_aes_key_apqns and testlib_env_ec_key_apqns which causes zpc_aes_key_set_apqns() be called with an invalid apqn parm.