### PR TITLE
CCA: Adjust CCA host library version detection for newer CCA versions

### DIFF
--- a/src/zkey/cca.c
+++ b/src/zkey/cca.c
@@ -106,7 +106,6 @@ static int get_cca_version(struct cca_lib *cca, bool verbose)
 	long return_code, reason_code;
 	long version_data_length;
 	long exit_data_len = 0;
-	char date[20];
 
 	util_assert(cca != NULL, "Internal error: cca is NULL");
 
@@ -137,8 +136,8 @@ static int get_cca_version(struct cca_lib *cca, bool verbose)
 	version_data[sizeof(version_data) - 1] = '\0';
 	pr_verbose(verbose, "CCA Version string: %s", version_data);
 
-	if (sscanf((char *)version_data, "%u.%u.%uz%s", &cca->version.ver,
-		   &cca->version.rel, &cca->version.mod, date) != 4) {
+	if (sscanf((char *)version_data, "%u.%u.%u", &cca->version.ver,
+		   &cca->version.rel, &cca->version.mod) != 3) {
 		DEBUG("CCA library version is invalid: %s", version_data);
 		return -EINVAL;
 	}


### PR DESCRIPTION
Newer CCA versions might report the version string with CSUACFV using a different indicator character after the version information. Ignore the indication character and the remaining data entirely. Only the version information as such is of interest.