### PR TITLE
zkey: Fix EP11 secure key reencipher function

### DIFF
--- a/src/zkey/ep11.c
+++ b/src/zkey/ep11.c
@@ -371,6 +371,9 @@ static int ep11_adm_reencrypt(struct ep11_lib *ep11, target_t target,
 
 	blob_len = ep11key_size;
 
+	memset(&rb, 0, sizeof(rb));
+	memset(&lrb, 0, sizeof(lrb));
+
 	rb.domain = domain;
 	lrb.domain = domain;
 


### PR DESCRIPTION
The verbose messages show the following debug message:
  "Command XCP_ADM_REENCRYPT failed. rc = 0x20"

This is due to uninitialized variables, which might cause the EP11 admin request to contain garbage data, causing it to fail with CKR_DATA_INVALID (0x20).