### PR TITLE
Fix map file

### DIFF
--- a/libzpc.map
+++ b/libzpc.map
@@ -110,11 +110,6 @@ global:
 	zpc_hmac_verify;
 	zpc_hmac_free;
 
-local: *;
-} ZPC_1.2.0;
-
-ZPC_1.4.0 {
-global:
 	zpc_aes_xts_key_alloc;
 	zpc_aes_xts_key_set_size;
 	zpc_aes_xts_key_set_type;
@@ -134,4 +129,4 @@ global:
 	zpc_aes_xts_full_free;
 
 local: *;
-} ZPC_1.3.0;
+} ZPC_1.2.0;


### PR DESCRIPTION
Support for HMAC and XTS-FULL come with the same release, so put the APIs together in one block. Note that 1.3.0 did not provide new APIs.