### PR TITLE
Fix API function mapping

### DIFF
--- a/libzpc.map
+++ b/libzpc.map
@@ -100,6 +100,9 @@ global:
 	zpc_hmac_key_alloc;
 	zpc_hmac_key_set_type;
 	zpc_hmac_key_set_hash_function;
+	zpc_hmac_key_import_clear;
+	zpc_hmac_key_import;
+	zpc_hmac_key_export;
 	zpc_hmac_key_generate;
 	zpc_hmac_key_free;
 

--- a/misc/apimapcheck
+++ b/misc/apimapcheck
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+process_file() {
+	echo "API Header: $1"
+	PROTOTYPES="$(${CTAGS} -x --kinds-c=p $1 2> /dev/null | cut -d" " -f1)"
+	# echo "PROTOTYPES: ${PROTOTYPES}"
+	for func in ${PROTOTYPES} ; do
+		echo -n "  ${func}: "
+		grep -q $func ${LIBZPC_MAP} || echo -n "!!! un"
+		echo "mapped"
+	done
+}
+
+echo_exit() {
+	echo "$*"
+	exit 1
+}
+
+FILES=${@:-"$(ls include/zpc/*.h 2> /dev/null)"}
+CTAGS="$(command -v ctags)"
+LIBZPC_MAP=${LIBZPC_MAP:-"libzpc.map"}
+
+test -n "${CTAGS}" || echo_exit "Required command missing: ctags"
+test -r ${LIBZPC_MAP} || echo_exit "Required map-file missing: ${LIBZPC_MAP}"
+
+for file in ${FILES}; do
+	test -r ${file} || continue
+	process_file ${file}
+done


### PR DESCRIPTION
The linker map-file is missing some of the new API functions, as described in #34. This PR add these missing functions.

As the process of checking the function mappings manually is error prone and annoying, a simple script is also added by this PR to check the mapping of all function prototypes, which are exposed in the header files. The scripts is meant to be used mainly in the release cycle, so there is no need for man-page or other documentation.