### PR TITLE
Maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-doc/html/
-doc/latex/
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,25 @@
 .vscode/
+
+# ignore common build directory
+/build/
+
+# ignore editor stubs
+\#*\#
+.*.swp
+
+# generic ignore patterns
+TAGS
+.TAGS
+!TAGS/
+tags
+.tags
+!tags/
+gtags.files
+GTAGS
+GRTAGS
+GPATH
+GSYMS
+cscope.files
+cscope.out
+cscope.in.out
+cscope.po.out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,12 +434,17 @@ find_package(Doxygen)
 if (DOXYGEN_FOUND)
 
 set(DOXYFILE
-    ${CMAKE_SOURCE_DIR}/doc/Doxyfile
+    ${CMAKE_BINARY_DIR}/doc/Doxyfile
 )
+set(DOXYFILE_IN
+    ${CMAKE_SOURCE_DIR}/doc/Doxyfile.in
+)
+configure_file(${DOXYFILE_IN} ${DOXYFILE} @ONLY)
 add_custom_target(doc
     ALL
     COMMAND           ${DOXYGEN_EXECUTABLE} ${DOXYFILE}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    VERBATIM
 )
 
 endif ()

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -8,7 +8,7 @@ PROJECT_NAME           = libzpc
 PROJECT_NUMBER         = 1.4
 PROJECT_BRIEF          = "IBM Z Protected-key Crypto library"
 PROJECT_LOGO           =
-OUTPUT_DIRECTORY       = doc
+OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/doc/
 CREATE_SUBDIRS         = NO
 CREATE_SUBDIRS_LEVEL   = 8
 ALLOW_UNICODE_NAMES    = NO
@@ -106,7 +106,7 @@ SHOW_FILES             = YES
 SHOW_NAMESPACES        = YES
 FILE_VERSION_FILTER    =
 LAYOUT_FILE            =
-CITE_BIB_FILES         = doc/references.bib
+CITE_BIB_FILES         = @CMAKE_SOURCE_DIR@/doc/references.bib
 #---------------------------------------------------------------------------
 # Configuration options related to warning and progress messages
 #---------------------------------------------------------------------------
@@ -124,10 +124,10 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = include/zpc \
-                         README.md \
-                         CHANGES.md \
-                         CONTRIBUTING.md
+INPUT                  = @CMAKE_SOURCE_DIR@/include/zpc \
+                         @CMAKE_SOURCE_DIR@/README.md \
+                         @CMAKE_SOURCE_DIR@/CHANGES.md \
+                         @CMAKE_SOURCE_DIR@/CONTRIBUTING.md
 INPUT_ENCODING         = UTF-8
 INPUT_FILE_ENCODING    =
 FILE_PATTERNS          = *.c \
@@ -185,7 +185,7 @@ EXCLUDE_SYMBOLS        =
 EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = NO
-IMAGE_PATH             = doc/
+IMAGE_PATH             = @CMAKE_SOURCE_DIR@/doc/
 INPUT_FILTER           =
 FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO


### PR DESCRIPTION
This PR moves the generation of the documentation from the source tree to the binary build directory. This avoids generated files in the source tree.
While at it, the update of the git ignore patterns makes it easier to track relevant changes to the source tree.