### PR TITLE
Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,9 @@ install(
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 
+###########################################################
+# Test
+
 option(BUILD_TEST OFF)
 
 if (BUILD_TEST)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 Contributing {#contrib}
 ===
 
-You can contribute to `libzpc` by submitting issues (feature requests, bug reports) or pull requests (code contributions) to the GitHub repository.
+You can contribute to `libzpc` by submitting issues (feature requests, bug
+reports) or pull requests (code contributions) to the GitHub repository.
 
 
 Bug reports
@@ -9,9 +10,11 @@ Bug reports
 
 When filing a bug report, please include all relevant information.
 
-In all cases include the `libzpc` version, operating system and kernel version used.
+In all cases include the `libzpc` version, operating system and kernel version
+used.
 
-Additionally, if it is a build error, include the toolchain version used. If it is a runtime error, include the crypto adapter config and processor model used.
+Additionally, if it is a build error, include the toolchain version used. If it
+is a runtime error, include the crypto adapter config and processor model used.
 
 Ideally, detailed steps on how to reproduce the issue would be included.
 
@@ -19,12 +22,20 @@ Ideally, detailed steps on how to reproduce the issue would be included.
 Code contributions
 ---
 
-All code contributions are reviewed by the `libzpc` maintainers who reverve the right to accept or reject a pull request.
+All code contributions are reviewed by the `libzpc` maintainers who reverve the
+right to accept or reject a pull request.
 
-Please state clearly if your pull request changes the `libzpc` API or ABI, and if so, whether the changes are backward compatible.
+Please state clearly if your pull request changes the `libzpc` API or ABI, and
+if so, whether the changes are backward compatible.
 
-If your pull request resolves an issue, please put a `"Fixes #<issue number>"` line in the commit message. Ideally, the pull request would add a corresponding regression test.
+If your pull request resolves an issue, please put a `"Fixes #<issue number>"`
+line in the commit message. Ideally, the pull request would add a corresponding
+regression test.
 
 If your pull request adds a new feature, please add a corresponding unit test.
 
-The code base is formatted using the `indent` tool with the options specified in the enclosed `.indent.pro` file. All code contributions must not violate this coding style. When formatting `libzpc` code, you can use `indent` with the prescribed options by copying the file to your home directory or by setting the `INDENT_PROFILE` environment variable's value to name the file.
+The code base is formatted using the `indent` tool with the options specified in
+the enclosed `.indent.pro` file. All code contributions must not violate this
+coding style. When formatting `libzpc` code, you can use `indent` with the
+prescribed options by copying the file to your home directory or by setting the
+`INDENT_PROFILE` environment variable's value to name the file.

--- a/include/zpc/ecc_key.h
+++ b/include/zpc/ecc_key.h
@@ -125,7 +125,7 @@ int zpc_ec_key_set_apqns(struct zpc_ec_key *key, const char *apqns[]);
  */
 __attribute__((visibility("default")))
 int zpc_ec_key_import(struct zpc_ec_key *key, const unsigned char *seckey,
-					unsigned int seckeylen);
+					size_t seckeylen);
 
 /**
  * Import an EC clear-key pair. At least one of the key parts must be non-NULL.
@@ -150,8 +150,8 @@ int zpc_ec_key_import(struct zpc_ec_key *key, const unsigned char *seckey,
  */
 __attribute__((visibility("default")))
 int zpc_ec_key_import_clear(struct zpc_ec_key *key,
-					const unsigned char *pubkey, unsigned int publen,
-					const unsigned char *privkey, unsigned int privlen);
+					const unsigned char *pubkey, size_t publen,
+					const unsigned char *privkey, size_t privlen);
 
 /**
  * Export an EC secure-key. Depending on the key type (CCA or EP11), the secure
@@ -166,7 +166,7 @@ int zpc_ec_key_import_clear(struct zpc_ec_key *key,
  */
 __attribute__((visibility("default")))
 int zpc_ec_key_export(struct zpc_ec_key *key, unsigned char *seckey,
-					unsigned int *seckeylen);
+					size_t *seckeylen);
 
 /**
  * Export an EC public-key.
@@ -180,7 +180,7 @@ int zpc_ec_key_export(struct zpc_ec_key *key, unsigned char *seckey,
  */
 __attribute__((visibility("default")))
 int zpc_ec_key_export_public(struct zpc_ec_key *key, unsigned char *pubkey,
-					unsigned int *pubkeylen);
+					size_t *pubkeylen);
 
 /**
  * Generate an EC secure-key.

--- a/include/zpc/ecdsa_ctx.h
+++ b/include/zpc/ecdsa_ctx.h
@@ -58,8 +58,8 @@ int zpc_ecdsa_ctx_set_key(struct zpc_ecdsa_ctx *ctx, struct zpc_ec_key *key);
  */
 __attribute__((visibility("default")))
 int zpc_ecdsa_sign(struct zpc_ecdsa_ctx *ctx,
-				const unsigned char *hash, unsigned int hash_len,
-				unsigned char *signature, unsigned int *sig_len);
+				const unsigned char *hash, size_t hash_len,
+				unsigned char *signature, size_t *sig_len);
 
 /**
  * Do an ECDSA verify operation.
@@ -72,8 +72,8 @@ int zpc_ecdsa_sign(struct zpc_ecdsa_ctx *ctx,
  */
 __attribute__((visibility("default")))
 int zpc_ecdsa_verify(struct zpc_ecdsa_ctx *ctx,
-				const unsigned char *hash, unsigned int hash_len,
-				const unsigned char *signature, unsigned int sig_len);
+				const unsigned char *hash, size_t hash_len,
+				const unsigned char *signature, size_t sig_len);
 
 /**
  * Free an ECDSA context.

--- a/s390x-tc-debian.cmake
+++ b/s390x-tc-debian.cmake
@@ -1,4 +1,5 @@
 set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR s390x)
 
 set(CMAKE_C_COMPILER   s390x-linux-gnu-gcc)
 set(CMAKE_CXX_COMPILER s390x-linux-gnu-g++)

--- a/src/ecc_key.c
+++ b/src/ecc_key.c
@@ -43,13 +43,13 @@ const u16 curve2pvsecret_type[] = {
 
 static void __ec_key_reset(struct zpc_ec_key *);
 static int ec_key_check_ep11_spki(const struct zpc_ec_key *ec_key,
-						const unsigned char *spki, unsigned int spki_len);
+						const unsigned char *spki, size_t spki_len);
 static void ec_key_use_maced_spki_from_buf(struct zpc_ec_key *ec_key,
-						const unsigned char *spki, unsigned int spki_len);
+						const unsigned char *spki, size_t spki_len);
 static int ec_key_use_raw_spki_from_buf(struct zpc_ec_key *ec_key,
-						const unsigned char *spki, unsigned int spki_len);
+						const unsigned char *spki, size_t spki_len);
 static int ec_key_spki_has_valid_mkvp(const struct zpc_ec_key *ec_key,
-						const unsigned char *spki, unsigned int spki_len);
+						const unsigned char *spki, size_t spki_len);
 static int ec_key_blob_has_valid_mkvp(struct zpc_ec_key *ec_key,
 						const unsigned char *buf);
 static int ec_key_blob_is_pkey_extractable(struct zpc_ec_key *ec_key,
@@ -492,7 +492,7 @@ ret:
 
 int
 zpc_ec_key_export(struct zpc_ec_key *ec_key, unsigned char *buf,
-				unsigned int *buflen)
+				size_t *buflen)
 {
 	int rc, rv;
 
@@ -558,7 +558,7 @@ ret:
 }
 
 int zpc_ec_key_export_public(struct zpc_ec_key *ec_key,
-						unsigned char *buf, unsigned int *buflen)
+						unsigned char *buf, size_t *buflen)
 {
 	int rc, rv;
 
@@ -613,7 +613,7 @@ ret:
 }
 
 int zpc_ec_key_import(struct zpc_ec_key *ec_key, const unsigned char *buf,
-				unsigned int buflen)
+				size_t buflen)
 {
 	target_t target;
 	int rc, rv, seclen;
@@ -789,8 +789,8 @@ ret:
 }
 
 int zpc_ec_key_import_clear(struct zpc_ec_key *ec_key, const unsigned char *pubkey,
-						unsigned int publen, const unsigned char *privkey,
-						unsigned int privlen)
+						size_t publen, const unsigned char *privkey,
+						size_t privlen)
 {
 	unsigned int flags;
 	int rc, rv;
@@ -1057,7 +1057,7 @@ ret:
 int zpc_ec_key_reencipher(struct zpc_ec_key *ec_key, unsigned int method)
 {
 	struct ec_key reenc;
-	unsigned int seckeylen;
+	size_t seckeylen;
 	target_t target;
 	int rv, rc = ZPC_ERROR_APQNSNOTSET;
 	size_t i;
@@ -1343,8 +1343,8 @@ int ec_key_pvsec2prot(struct zpc_ec_key *ec_key)
 }
 
 int ec_key_clr2sec(struct zpc_ec_key *ec_key, unsigned int flags,
-			const unsigned char *pubkey, unsigned int publen,
-			const unsigned char *privkey, unsigned int privlen)
+			const unsigned char *pubkey, size_t publen,
+			const unsigned char *privkey, size_t privlen)
 {
 	target_t target;
 	int rv, rc = ZPC_ERROR_APQNSNOTSET;
@@ -1400,7 +1400,7 @@ int ec_key_sec2prot(struct zpc_ec_key *ec_key, enum ec_key_sec sec)
 {
 	struct pkey_kblob2pkey3 io;
 	struct ec_key *key = NULL;
-	unsigned int keybuf_len;
+	size_t keybuf_len;
 	int rc, i;
 
 	assert(sec == EC_KEY_SEC_OLD || sec == EC_KEY_SEC_CUR);
@@ -1442,7 +1442,7 @@ int ec_key_sec2prot(struct zpc_ec_key *ec_key, enum ec_key_sec sec)
 }
 
 int ec_key_clr2prot(struct zpc_ec_key *ec_key, const unsigned char *privkey,
-					unsigned int privlen)
+					size_t privlen)
 {
 	struct pkey_kblob2pkey3 io;
 	unsigned char buf[sizeof(struct clearkeytoken) + 80];
@@ -1529,7 +1529,7 @@ int ec_key_spki_valid_for_pubkey(const struct zpc_ec_key *ec_key,
 }
 
 static int ec_key_check_ep11_spki(const struct zpc_ec_key *ec_key,
-							const unsigned char *spki, unsigned int spki_len)
+							const unsigned char *spki, size_t spki_len)
 {
 	if (spki_len > curve2macedspkilen[ec_key->curve] &&
 		spki_len < curve2rawspkilen[ec_key->curve])
@@ -1550,7 +1550,7 @@ static int ec_key_check_ep11_spki(const struct zpc_ec_key *ec_key,
 }
 
 static void ec_key_use_maced_spki_from_buf(struct zpc_ec_key *ec_key,
-						const unsigned char *spki, unsigned int spki_len)
+						const unsigned char *spki, size_t spki_len)
 {
 	memcpy(ec_key->pub.spki, spki, spki_len);
 	ec_key->pub.spkilen = spki_len;
@@ -1563,7 +1563,7 @@ static void ec_key_use_maced_spki_from_buf(struct zpc_ec_key *ec_key,
 }
 
 static int ec_key_use_raw_spki_from_buf(struct zpc_ec_key *ec_key,
-						const unsigned char *spki, unsigned int spki_len)
+						const unsigned char *spki, size_t spki_len)
 {
 	target_t target;
 	int rc = -EIO, rv;
@@ -1600,7 +1600,7 @@ static int ec_key_use_raw_spki_from_buf(struct zpc_ec_key *ec_key,
 }
 
 static int ec_key_spki_has_valid_mkvp(const struct zpc_ec_key *ec_key,
-						const unsigned char *spki, unsigned int spki_len)
+						const unsigned char *spki, size_t spki_len)
 {
 	(void)spki_len; /* suppress unused parm compiler warning */
 
@@ -1618,7 +1618,7 @@ static int ec_key_spki_has_valid_mkvp(const struct zpc_ec_key *ec_key,
 static int ec_key_blob_has_valid_mkvp(struct zpc_ec_key *ec_key, const unsigned char *buf)
 {
 	const unsigned char *mkvp;
-	unsigned int mkvp_len;
+	size_t mkvp_len;
 
 	if (ec_key->mkvp_set == 0)
 		return 1; /* cannot judge */

--- a/src/ecc_key_local.h
+++ b/src/ecc_key_local.h
@@ -59,10 +59,10 @@ struct zpc_ec_key {
 };
 
 int ec_key_clr2sec(struct zpc_ec_key *ec_key, unsigned int flags,
-			const unsigned char *pubkey, unsigned int publen,
-			const unsigned char *privkey, unsigned int privlen);
+			const unsigned char *pubkey, size_t publen,
+			const unsigned char *privkey, size_t privlen);
 int ec_key_sec2prot(struct zpc_ec_key *, enum ec_key_sec sec);
 int ec_key_check(const struct zpc_ec_key *);
 int ec_key_clr2prot(struct zpc_ec_key *ec_key, const unsigned char *privkey,
-			unsigned int privlen);
+			size_t privlen);
 #endif

--- a/src/ecdsa_ctx.c
+++ b/src/ecdsa_ctx.c
@@ -27,19 +27,19 @@
 extern const size_t curve2siglen[];
 
 static int __ec_sign(struct zpc_ecdsa_ctx *, const unsigned char *hash,
-		unsigned int hash_len, unsigned char *signature, unsigned int *sig_len);
+		size_t hash_len, unsigned char *signature, size_t *sig_len);
 static int __ec_verify(struct zpc_ecdsa_ctx *, const unsigned char *hash,
-		unsigned int hash_len, const unsigned char *signature, unsigned int sig_len);
+		size_t hash_len, const unsigned char *signature, size_t sig_len);
 static void __ec_ctx_reset(struct zpc_ecdsa_ctx *);
 static void __copy_hash_to_sign_param(struct zpc_ecdsa_ctx *ctx,
-		const unsigned char *hash, unsigned int hash_len);
+		const unsigned char *hash, size_t hash_len);
 static void __get_signature_from_sign_param(struct zpc_ecdsa_ctx *ctx,
-		unsigned char *signature, unsigned int sig_len);
+		unsigned char *signature, size_t sig_len);
 static void __copy_pubkey_to_verify_param(struct zpc_ecdsa_ctx *ctx);
 static void __copy_protkey_to_sign_param(struct zpc_ecdsa_ctx *ctx);
 static void __copy_args_to_verify_param(struct zpc_ecdsa_ctx *ctx,
-		const unsigned char *hash, unsigned int hash_len,
-		const unsigned char *signature, unsigned int sig_len);
+		const unsigned char *hash, size_t hash_len,
+		const unsigned char *signature, size_t sig_len);
 static void __cleanup_verify_param(struct zpc_ecdsa_ctx *ctx);
 static void __cleanup_sign_param(struct zpc_ecdsa_ctx *ctx);
 
@@ -182,8 +182,8 @@ ret:
 }
 
 int zpc_ecdsa_sign(struct zpc_ecdsa_ctx *ctx,
-			const unsigned char *hash, unsigned int hash_len,
-			unsigned char *signature, unsigned int *sig_len)
+			const unsigned char *hash, size_t hash_len,
+			unsigned char *signature, size_t *sig_len)
 {
 	int rc, rv, i;
 
@@ -274,8 +274,8 @@ ret:
 }
 
 int zpc_ecdsa_verify(struct zpc_ecdsa_ctx *ctx,
-			const unsigned char *hash, unsigned int hash_len,
-			const unsigned char *signature, unsigned int sig_len)
+			const unsigned char *hash, size_t hash_len,
+			const unsigned char *signature, size_t sig_len)
 {
 	int rc, rv;
 
@@ -358,8 +358,8 @@ void zpc_ecdsa_ctx_free(struct zpc_ecdsa_ctx **ctx)
 }
 
 static int __ec_sign(struct zpc_ecdsa_ctx *ctx,
-				const unsigned char *hash, unsigned int hash_len,
-				unsigned char *signature, unsigned int *sig_len)
+				const unsigned char *hash, size_t hash_len,
+				unsigned char *signature, size_t *sig_len)
 {
 	void *param;
 	int rc, cc;
@@ -391,8 +391,8 @@ err:
 }
 
 static int __ec_verify(struct zpc_ecdsa_ctx *ctx,
-				const unsigned char *hash, unsigned int hash_len,
-				const unsigned char *signature, unsigned int sig_len)
+				const unsigned char *hash, size_t hash_len,
+				const unsigned char *signature, size_t sig_len)
 {
 	void *param;
 	int rc = ZPC_ERROR_EC_SIGNATURE_INVALID, cc;
@@ -431,7 +431,7 @@ static void __ec_ctx_reset(struct zpc_ecdsa_ctx *ctx)
 }
 
 static void __copy_hash_to_sign_param(struct zpc_ecdsa_ctx *ctx,
-						const unsigned char *hash, unsigned int hash_len)
+						const unsigned char *hash, size_t hash_len)
 {
 	switch (ctx->ec_key->curve) {
 	case ZPC_EC_CURVE_P256:
@@ -455,7 +455,7 @@ static void __copy_hash_to_sign_param(struct zpc_ecdsa_ctx *ctx,
 }
 
 static void __get_signature_from_sign_param(struct zpc_ecdsa_ctx *ctx,
-								unsigned char *signature, unsigned int sig_len)
+								unsigned char *signature, size_t sig_len)
 {
 	switch (ctx->ec_key->curve) {
 	case ZPC_EC_CURVE_P256:
@@ -538,8 +538,8 @@ static void __copy_protkey_to_sign_param(struct zpc_ecdsa_ctx *ctx)
 }
 
 static void __copy_args_to_verify_param(struct zpc_ecdsa_ctx *ctx,
-						const unsigned char *hash, unsigned int hash_len,
-						const unsigned char *signature, unsigned int sig_len)
+						const unsigned char *hash, size_t hash_len,
+						const unsigned char *signature, size_t sig_len)
 {
 	switch (ctx->ec_key->curve) {
 	case ZPC_EC_CURVE_P256:

--- a/test/t_ecc_key.cc
+++ b/test/t_ecc_key.cc
@@ -489,7 +489,7 @@ TEST(ec_key, export)
 {
 	struct zpc_ec_key *ec_key, *ec_key2;
 	u8 buf[2000], buf2[2000];
-	unsigned int buflen, buflen2, flags;
+	size_t buflen, buflen2, flags;
 	const char *apqns[257];
 	int rc, type;
 	zpc_ec_curve_t curve;
@@ -583,7 +583,8 @@ TEST(ec_key, export_public)
 {
 	struct zpc_ec_key *ec_key;
 	u8 buf[132];
-	unsigned int buflen, flags;
+	unsigned int flags;
+	size_t buflen;
 	const char *apqns[257];
 	int rc, type;
 	zpc_ec_curve_t curve;
@@ -656,8 +657,8 @@ TEST(ec_key, import)
 {
 	struct zpc_ec_key *ec_key, *ec_key2;
 	u8 buf[10000], buf2[10000];
-	unsigned int buflen = sizeof(buf);
-	unsigned int buf2len = sizeof(buf2);
+	size_t buflen = sizeof(buf);
+	size_t buf2len = sizeof(buf2);
 	unsigned int flags;
 	const char *apqns[257];
 	const char *mkvp;
@@ -757,10 +758,10 @@ TEST(ec_key, spki_test)
 	struct zpc_ec_key *ec_key, *ec_key2;
 	unsigned int pubkeylen, privkeylen, blob_len, pubkey_offset;
 	u8 buf[3000] = {0}, buf2[3000] = {0}, buf3[132] = {0}, buf4[3000] = {0};
-	unsigned int buflen = sizeof(buf);
-	unsigned int buf2len = sizeof(buf2);
-	unsigned int buf3len = sizeof(buf3);
-	unsigned int buf4len = sizeof(buf4);
+	size_t buflen = sizeof(buf);
+	size_t buf2len = sizeof(buf2);
+	size_t buf3len = sizeof(buf3);
+	size_t buf4len = sizeof(buf4);
 	unsigned int flags;
 	const char *apqns[257];
 	const char *mkvp;

--- a/test/t_ecdsa_ctx.cc
+++ b/test/t_ecdsa_ctx.cc
@@ -105,7 +105,8 @@ TEST(ecdsa_ctx, set_key)
 {
 	struct zpc_ec_key *ec_key;
 	struct zpc_ecdsa_ctx *ec_ctx;
-	unsigned int pubkeylen, privkeylen, flags = 0;
+	size_t pubkeylen, privkeylen;
+	unsigned int flags = 0;
 	const char *mkvp, *apqns[257];
 	int rc, type;
 	zpc_ec_curve_t curve;
@@ -183,7 +184,8 @@ TEST(ecdsa_ctx, sign)
 	struct zpc_ecdsa_ctx *ec_ctx;
 	const char *mkvp, *apqns[257];
 	u8 msg[1000], signature[200];
-	unsigned int msg_len, sig_len, flags;
+	size_t msg_len, sig_len;
+	unsigned int flags;
 	int rc, type;
 	zpc_ec_curve_t curve;
 	const unsigned int test_msglen_from_curve[] = { 32, 48, 64, 500, 1000 };
@@ -260,8 +262,8 @@ TEST(ecdsa_ctx, verify)
 	const char *mkvp, *apqns[257];
 	u8 signature[200];
 	u8 buf[200];
-	unsigned int signature_len, hash_len, sig_len, buflen;
-	unsigned int pubkeylen, flags;
+	size_t signature_len, hash_len, sig_len, buflen, pubkeylen;
+	unsigned int flags;
 	int rc, type;
 	zpc_ec_curve_t curve;
 
@@ -397,7 +399,7 @@ TEST(ecdsa_ctx, sv)
 	struct zpc_ec_key *ec_key1, *ec_key2;
 	struct zpc_ecdsa_ctx *ec_ctx1, *ec_ctx2;
 	u8 sigbuf[200];
-	unsigned int hash_len, sig_len, pubkeylen, privkeylen;
+	size_t hash_len, sig_len, pubkeylen, privkeylen;
 	const char *mkvp, *apqns[257];
 	unsigned int flags;
 	int rc, type;
@@ -607,8 +609,8 @@ static zpc_ec_curve_t __str2curve(const char *str)
 }
 
 static void __get_ec_params_from_json(json_object *jtmp, zpc_ec_curve_t curve,
-				u8 *priv, unsigned int *privlen, u8 *pub, unsigned int *publen,
-				u8 *msg, unsigned int *msglen, u8 *sig, unsigned int *siglen)
+				u8 *priv, size_t *privlen, u8 *pub, size_t *publen,
+				u8 *msg, size_t *msglen, u8 *sig, size_t *siglen)
 {
 	json_object *jd, *jx, *jy, *jmsg, *jsig_r, *jsig_s;
 	json_bool b;
@@ -683,8 +685,8 @@ static void __get_ec_params_from_json(json_object *jtmp, zpc_ec_curve_t curve,
 }
 
 static void __get_ed_params_from_json(json_object *jtmp,
-		u8 *priv, unsigned int *privlen, u8 *pub, unsigned int *publen,
-		u8 *msg, unsigned int *msglen, u8 *sig, unsigned int *siglen)
+		u8 *priv, size_t *privlen, u8 *pub, size_t *publen,
+		u8 *msg, size_t *msglen, u8 *sig, size_t *siglen)
 {
 	json_object *jd, *jq, *jm, *js;
 	json_bool b;
@@ -763,8 +765,8 @@ static void __get_result_from_json(json_object *jresult, int *valid)
  * Get key material from json 'key' entry
  */
 static void __get_key_from_json(json_object *jkey, zpc_ec_curve_t curve,
-							unsigned char *pubbuf, unsigned int *publen,
-							unsigned char *privbuf, unsigned int *privlen)
+							unsigned char *pubbuf, size_t *publen,
+							unsigned char *privbuf, size_t *privlen)
 {
 	json_object *jwx, *jwy, *jsk, *jpk;
 	json_bool b;
@@ -827,7 +829,7 @@ done:
 }
 
 static void __get_bytes_from_json(json_object *jobj, unsigned char *buf,
-							unsigned int *len)
+							size_t *len)
 {
 	const char *str;
 	u8 *bytes = NULL;
@@ -849,9 +851,9 @@ static void __get_bytes_from_json(json_object *jobj, unsigned char *buf,
 }
 
 static void __run_sign_verify_test(zpc_ecdsa_ctx *ec_ctx,
-						unsigned char *msgbuf, unsigned int msglen,
-						unsigned char *sigbuf1, unsigned int *siglen1,
-						unsigned int privlen)
+						unsigned char *msgbuf, size_t msglen,
+						unsigned char *sigbuf1, size_t *siglen1,
+						size_t privlen)
 {
 	int rc;
 
@@ -865,8 +867,8 @@ static void __run_sign_verify_test(zpc_ecdsa_ctx *ec_ctx,
 }
 
 static void __run_verify_kat_test(zpc_ecdsa_ctx *ec_ctx, zpc_ec_curve_t curve,
-						unsigned char *msgbuf, unsigned int msglen,
-						unsigned char *sigbuf2, unsigned int siglen2,
+						unsigned char *msgbuf, size_t msglen,
+						unsigned char *sigbuf2, size_t siglen2,
 						int expected_valid)
 {
 	int rc;
@@ -933,8 +935,8 @@ static void __run_nist_tests(json_object *jtestgroups, struct zpc_ec_key *ec_key
 
 			u8 pubbuf[200] = { 0 }, privbuf[100] = { 0 };
 			u8 sigbuf1[200] = { 0 }, sigbuf2[200] = { 0 }, msgbuf[4096] = { 0 };
-			unsigned int siglen1 = sizeof(sigbuf1), siglen2 = sizeof(sigbuf2);
-			unsigned int privlen, publen, msglen;
+			size_t siglen1 = sizeof(sigbuf1), siglen2 = sizeof(sigbuf2);
+			size_t privlen, publen, msglen;
 
 			jtmp = json_object_array_get_idx(jtests, j);
 			ASSERT_NE(jtmp, nullptr);
@@ -1002,8 +1004,8 @@ static void __run_wycheproof_tests(json_object *jtestgroups, struct zpc_ec_key *
 
 		u8 sigbuf1[200] = { 0 }, sigbuf2[200] = { 0 }, msgbuf[4096] = { 0 };
 		u8 pubbuf[200] = { 0 }, privbuf[100] = { 0 };
-		unsigned int siglen1 = sizeof(sigbuf1), siglen2 = sizeof(sigbuf2);
-		unsigned int privlen, publen, msglen;
+		size_t siglen1 = sizeof(sigbuf1), siglen2 = sizeof(sigbuf2);
+		size_t privlen, publen, msglen;
 
 		jtmp = json_object_array_get_idx(jtestgroups, i);
 		ASSERT_NE(jtmp, nullptr);
@@ -1115,7 +1117,7 @@ static void __run_json(const char *json)
 
 TEST(ecdsa_ctx, rederive_protected_key)
 {
-	unsigned int pubkeylen, privkeylen, msg_len, sig_len;
+	size_t pubkeylen, privkeylen, msg_len, sig_len;
 	zpc_ec_curve_t curve;
 	unsigned char buf[4096];
 	const char *mkvp, *apqns[257];
@@ -1206,7 +1208,7 @@ ret:
 
 TEST(ecdsa_ctx, reencipher)
 {
-	unsigned int pubkeylen, privkeylen, msg_len, sig_len;
+	size_t pubkeylen, privkeylen, msg_len, sig_len;
 	unsigned char buf[4096];
 	const char *mkvp, *apqns[257];
 	struct zpc_ec_key *ec_key;
@@ -1298,9 +1300,9 @@ TEST(ecdsa_ctx, reencipher)
 
 TEST(ecdsa_ctx, use_existing)
 {
-	unsigned int pubkeylen, privkeylen, msg_len, sig_len, signature_len;
+	size_t pubkeylen, privkeylen, msg_len, sig_len, signature_len;
 	unsigned char buf[4096], signature[132];
-	unsigned int buflen;
+	size_t buflen;
 	const char *mkvp, *apqns[257];
 	struct zpc_ec_key *ec_key, *ec_key2;
 	struct zpc_ecdsa_ctx *ec_ctx;
@@ -1435,8 +1437,8 @@ TEST(ecdsa_ctx, use_existing)
 TEST(ecdsa_ctx, pvsecret_kat)
 {
 	unsigned char sig1[132], sig2[132], pubkey[200], msg[32];
-	unsigned int sig1_len = sizeof(sig1), sig2_len = sizeof(sig2);
-	unsigned int msg_len = sizeof(msg), publen = sizeof(pubkey);
+	size_t sig1_len = sizeof(sig1), sig2_len = sizeof(sig2);
+	size_t msg_len = sizeof(msg), publen = sizeof(pubkey);
 	const char *mkvp, *apqns[257];
 	struct zpc_ec_key *ec_key1, *ec_key2;
 	struct zpc_ecdsa_ctx *ec_ctx1, *ec_ctx2;
@@ -1579,7 +1581,7 @@ static void __task(struct zpc_ec_key *ec_key)
 {
 	struct zpc_ecdsa_ctx *ec_ctx;
 	unsigned char sigbuf[200];
-	unsigned int msglen, siglen;
+	size_t msglen, siglen;
 	int rc, i;
 
 	const u8 *msg = ec_tv[ec_key->curve].msg;
@@ -1624,7 +1626,7 @@ static void __task(struct zpc_ec_key *ec_key)
 
 TEST(ecdsa_ctx, threads)
 {
-	unsigned int pubkeylen, privkeylen;
+	size_t pubkeylen, privkeylen;
 	const char *mkvp, *apqns[257];
 	struct zpc_ec_key *ec_key;
 	unsigned int flags;


### PR DESCRIPTION
This PR covers a few cleanups as preparation for the provider support. The most important one is the harmonization of the zpc API. As it breaks the former external API it will only go into v2 (and not in any of the libzpc1.* maintenance branches).