### PR TITLE
AES/ECC: Fix missing unlock if calloc for APQNs fails

### DIFF
--- a/src/aes_key.c
+++ b/src/aes_key.c
@@ -410,8 +410,10 @@ zpc_aes_key_set_apqns(struct zpc_aes_key *aes_key, const char *apqns[])
 	}
 
 	aes_key->apqns = calloc(napqns, sizeof(*(aes_key->apqns)));
-	if (aes_key->apqns == NULL)
-		return ZPC_ERROR_MALLOC;
+	if (aes_key->apqns == NULL) {
+		rc = ZPC_ERROR_MALLOC;
+		goto ret;
+	}
 
 	for (i = 0; i < napqns; i++) {
 		rc = sscanf(apqns[i], " %x.%x ", &card, &domain);

--- a/src/ecc_key.c
+++ b/src/ecc_key.c
@@ -446,8 +446,10 @@ int zpc_ec_key_set_apqns(struct zpc_ec_key *ec_key, const char *apqns[])
 	}
 
 	ec_key->apqns = calloc(napqns, sizeof(*(ec_key->apqns)));
-	if (ec_key->apqns == NULL)
-		return ZPC_ERROR_MALLOC;
+	if (ec_key->apqns == NULL) {
+		rc = ZPC_ERROR_MALLOC;
+		goto ret;
+	}
 
 	for (i = 0; i < napqns; i++) {
 		rc = sscanf(apqns[i], " %x.%x ", &card, &domain);


### PR DESCRIPTION
Fix an early return and go to the 'ret' label instead to let it perform the unlock and other cleanup.